### PR TITLE
Fix Clippy collapsible-if warning

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -183,23 +183,21 @@ impl LayoutConfig {
         // Find the first pane with horizontal split (usually the terminal pane)
         for (index, pane) in self.panes.iter().enumerate() {
             if pane.split.as_deref() == Some("horizontal") {
-                if let Some(size) = &pane.size {
-                    if size.ends_with('%') {
-                        let percentage = size.trim_end_matches('%');
-                        // This controls the overall top/bottom ratio
-                        Command::new("tmux")
-                            .args([
-                                "resize-pane",
-                                "-t",
-                                &index.to_string(),
-                                "-y",
-                                &format!("{}%", percentage),
-                            ])
-                            .status()
-                            .map_err(|e| {
-                                format!("Failed to adjust row height for pane {}: {}", index, e)
-                            })?;
-                    }
+                if let Some(size) = pane.size.as_ref().filter(|s| s.ends_with('%')) {
+                    let percentage = size.trim_end_matches('%');
+                    // This controls the overall top/bottom ratio
+                    Command::new("tmux")
+                        .args([
+                            "resize-pane",
+                            "-t",
+                            &index.to_string(),
+                            "-y",
+                            &format!("{}%", percentage),
+                        ])
+                        .status()
+                        .map_err(|e| {
+                            format!("Failed to adjust row height for pane {}: {}", index, e)
+                        })?;
                 }
                 break; // Only adjust the first horizontal split
             }


### PR DESCRIPTION
Closes #23

The release pipeline was failing due to a Clippy warning in `src/layout.rs`: `error: this if statement can be collapsed`. 

This PR replaces the nested `if let` and `if` blocks with a single `if let` using `.filter()` to satisfy the `collapsible-if` rule while maintaining compatibility and ensuring all CI checks pass.